### PR TITLE
Minor bug in seed script prevents passing URLs directly during run to work

### DIFF
--- a/src/locutus_util/__init__.py
+++ b/src/locutus_util/__init__.py
@@ -152,11 +152,11 @@ def resolve_environment(env_or_uri):
             f"Environment '{env_or_uri}' found in configuration file. Using value: {CONFIGS["envs"][env_or_uri]}"
         )
         return value
-    if env_or_uri in envs:
-        logger.info(
-            f"Environment '{env_or_uri}' not found in configuration file. Using provided URI: {env_or_uri}"
-        )
-        return env_or_uri
+        
+    logger.info(
+        f"Environment '{env_or_uri}' not found in configuration file. Using provided URI: {env_or_uri}"
+    )
+    return env_or_uri
 
 
 def init_database(mongo_uri=None, project_id=None, missing_db_ok=False):

--- a/src/locutus_util/_version.py
+++ b/src/locutus_util/_version.py
@@ -28,7 +28,7 @@ version_tuple: VERSION_TUPLE
 commit_id: COMMIT_ID
 __commit_id__: COMMIT_ID
 
-__version__ = version = '2.0.2.dev0+g3db0841f1.d20251110'
-__version_tuple__ = version_tuple = (2, 0, 2, 'dev0', 'g3db0841f1.d20251110')
+__version__ = version = '2.0.5.dev0+gfd36d971a.d20251112'
+__version_tuple__ = version_tuple = (2, 0, 5, 'dev0', 'gfd36d971a.d20251112')
 
-__commit_id__ = commit_id = 'g3db0841f1'
+__commit_id__ = commit_id = 'gfd36d971a'

--- a/src/locutus_util/seed_etl/README.md
+++ b/src/locutus_util/seed_etl/README.md
@@ -12,6 +12,17 @@ Process:
 ## seed_database_etl.py
 Overview:
 - Formats normalized data into json to be used as the body of a request to 'locutus' to:<br> 1. Add the Terminology to the db or <br> 2. Delete codes from that Terminology in the db.
+
+### Bare API URL
+For convenience, we have built in support for environment configuration to short cut some typing (and memory if the API URLs are long or ugly). For one off runs, you can just provide the base URL. For example, if I want my database that a local version of locutus is using, I might use the following url:
+
+```bash
+seed_data ---locutus-url http://localhost:5000 
+```
+
+This will load the seeds into locutus running on localhost listening on port 5000. 
+
+### To use the environments
 Process:
 - Make any necessary edits to `locutus_util/data/seed_etl/seed_config.yaml`. See the documentation on this file below for more information.
 - From locutus_util run:  `python seed_etl/seed_database.py -e {env} -a {action}`

--- a/src/locutus_util/seed_etl/seed_data_etl.py
+++ b/src/locutus_util/seed_etl/seed_data_etl.py
@@ -59,7 +59,7 @@ def main():
     )
     args = parser.parse_args()
 
-    resolved_uri = resolve_environment(args.database_uri)
+    resolved_uri = resolve_environment(args.locutus_url)
 
     logger.info(f"STARTED {args.action}")
 

--- a/src/locutus_util/seed_etl/seed_data_etl.py
+++ b/src/locutus_util/seed_etl/seed_data_etl.py
@@ -46,9 +46,9 @@ def main():
 
     parser = argparse.ArgumentParser(description="Load CSV data into Firestore.")
     parser.add_argument(
-        "-db",
-        "--database_uri",
-        help="Will be used as the base uri in an api request to locutus. Use a uri or environment name from '{CONFIG_FILE_PATH}'.",
+        "-url",
+        "--locutus-url",
+        help="Will be used as the base URL in an API request to locutus. Use an API URL or environment name from '{CONFIG_FILE_PATH}'.",
     )
     parser.add_argument(
         '-a',


### PR DESCRIPTION
Fixed an bug related to seeding database with an API url that isn't part of the config. 